### PR TITLE
Use runez 4.x compatible, fixing api breakage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pinned
 click~=8.0
 requests~=2.27
-runez==3.7.1
+runez~=4.0
 urllib3~=1.26

--- a/src/pickley/__init__.py
+++ b/src/pickley/__init__.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime
 
 import runez
-from runez.pyenv import PypiStd, PythonDepot, PythonInstallationScanner, Version
+from runez.pyenv import PypiStd, PythonDepot, Version
 
 
 __version__ = "3.5.6"
@@ -185,11 +185,11 @@ class PackageSpec:
         return str(self) < str(other)
 
     @runez.cached_property
-    def python(self):
+    def python(self):  # noqa: F811
         return self.cfg.find_python(self)
 
     @runez.cached_property
-    def settings(self):
+    def settings(self):  # noqa: F811
         return TrackedSettings(
             delivery=self.cfg.delivery_method(self),
             index=self.cfg.index(self) or self.cfg.default_index,
@@ -198,7 +198,7 @@ class PackageSpec:
         )
 
     @runez.cached_property
-    def pinned(self):
+    def pinned(self):  # noqa: F811
         return self.cfg.pinned_version(self)
 
     @runez.cached_property
@@ -325,9 +325,8 @@ class PackageSpec:
                     if not runez.is_executable(exe_path):
                         return False
 
-            py_path = self.cfg.available_pythons.resolved_python_exe(self.active_install_path)
-            if py_path:
-                return runez.run(py_path, "--version", dryrun=False, fatal=False, logger=False).succeeded
+            py_path = os.path.join(self.active_install_path, "bin/python")
+            return runez.run(py_path, "--version", dryrun=False, fatal=False, logger=False).succeeded
 
     def find_wheel(self, folder, fatal=True):
         """list[str]: Wheel for this package found in 'folder', if any"""
@@ -451,13 +450,8 @@ class PickleyConfig:
     @runez.cached_property
     def available_pythons(self):
         pyenv = self.pyenv()
-        scanner = PythonInstallationScanner(pyenv) if pyenv else None
-        depot = PythonDepot(scanner=scanner)
-        depot.find_preferred_python(
-            self.get_value("preferred_pythons"),
-            min_python=self.get_value("min_python"),
-            preferred_min_python=self.get_value("preferred_min_python")
-        )
+        python_locations = [pyenv] if pyenv else []
+        depot = PythonDepot(*python_locations)
         return depot
 
     def set_base(self, base_path):

--- a/src/pickley/cli.py
+++ b/src/pickley/cli.py
@@ -405,7 +405,6 @@ def _diagnostics():
 @main.command()
 def diagnostics():
     """Show diagnostics info"""
-    CFG.available_pythons.scan_path_env_var()
     print(PrettyTable.two_column_diagnostics(_diagnostics(), runez.SYS_INFO.diagnostics(), CFG.available_pythons.representation()))
 
 
@@ -679,7 +678,7 @@ def parsed_version(text):
     """Parse --version from text, in reverse order to avoid being fulled by warnings..."""
     if text:
         for line in reversed(text.splitlines()):
-            version = Version.from_text(line)
+            version = Version.extracted_from_text(line)
             if version:
                 return version
 

--- a/src/pickley/package.py
+++ b/src/pickley/package.py
@@ -174,13 +174,13 @@ class PythonVenv:
         if r.failed or (not runez.DRYRUN and not self.pip_path):
             return self._old_virtualenv(runner, "latest")
 
-        pip_spec = pip_version(self.python.version.components)
+        pip_spec = pip_version(self.python.full_version.components)
         pip_spec = f"pip=={pip_spec}" if pip_spec else "pip"
         return self.run_pip("install", "-U", pip_spec)
 
     def _old_virtualenv(self, runner, vv):
         """Create a virtualenv using old virtualenv module"""
-        pv = self.python.version.components
+        pv = self.python.full_version.components
         if not vv or vv == "latest":
             vv = PackageSpec(self.pspec.cfg, "virtualenv")
             vv = vv.desired_track.version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,5 +48,4 @@ def temp_cfg():
     with TemporaryBase() as base:
         cfg = PickleyConfig()
         cfg.set_base(base)
-        cfg.available_pythons.find_preferred_python("")
         yield cfg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,8 +76,8 @@ def test_bogus_config(temp_folder, logged):
 
     p = cfg.find_python(pspec=None, fatal=False)
     assert p.executable == "/dev/null/foo"
-    assert p.problem == "not an executable"
-    assert "skipped: not an executable" in logged.pop()
+    assert p.problem == "/dev/null/foo is not an executable"
+    assert "skipped: /dev/null/foo is not an executable" in logged.pop()
 
     assert not logged
     p = PackageSpec(cfg, "mgit")

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -38,7 +38,7 @@ def test_edge_cases(temp_cfg, logged):
     runez.touch(f"{DOT_META}/.cache/virtualenv-20.13.0.pyz")
     with patch("runez.run", return_value=runez.program.RunResult(code=0)):
         cmd = venv._create_virtualenv(runner=lambda *x: x)
-        if temp_cfg.available_pythons.invoker.version < "3.7":
+        if temp_cfg.available_pythons.invoker.full_version < "3.7":
             assert cmd[4] == "--pip"
 
         else:


### PR DESCRIPTION
Note: the "tox -e style" run flags an unrelated issue around reused names, because flake8 isn't pinned.  Those are worked around with the noqa lines.