### PR TITLE
Change config key `pyenv` -> `python-installations`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ jobs:
         language: [ 'python' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,29 +9,19 @@ jobs:
   publish:
 
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write  # mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
-    - run: pip install -U pip setuptools wheel twine tox
+    - run: pip install -U pip setuptools wheel tox
     - run: tox -e py,docs,style
     - run: python setup.py sdist bdist_wheel
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        draft: false
-        prerelease: false
-
-    - name: Publish sdist and wheel
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PICKLEY }}
-      run: twine upload dist/*
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -34,10 +34,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ['3.6', '3.7']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: '3.11'
 
     - run: pip install -U pip tox
     - run: tox -e docs,style,security

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Automate installation of standalone python CLIs
     :target: https://github.com/codrsquad/pickley/actions
     :alt: Tested with Github Actions
 
-.. image:: https://codecov.io/gh/codrsquad/pickley/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/codrsquad/pickley/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/codrsquad/pickley
     :alt: Test code codecov
 
@@ -55,7 +55,7 @@ Example
 Once you have ``pickley``, you can get other python CLIs and use them as standalone programs, for example::
 
     # One-liner to grab pickley, and drop it in ~/.local/bin
-    $ curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/master/src/pickley/bstrap.py | /usr/bin/python3 -
+    $ curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/main/src/pickley/bstrap.py | /usr/bin/python3 -
 
     # Double-check you do have ~/.local/bin in your PATH
     $ which -a pickley
@@ -118,12 +118,12 @@ Install latest version in `~/.local/bin`
 
 Handy one-line using ``bash``::
 
-    $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/master/get-pickley)"
+    $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/main/get-pickley)"
 
 
 Handy one-liner using python (see ``--help``, the script accepts a few options)::
 
-    $ curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/master/src/pickley/bstrap.py | /usr/bin/python3 - --help
+    $ curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/main/src/pickley/bstrap.py | /usr/bin/python3 - --help
 
 
 Install from source

--- a/get-pickley
+++ b/get-pickley
@@ -30,7 +30,7 @@ if [[ -x get-pickley && -f $bstrap ]]; then
   script=$bstrap
 else
   script=$TMP_FOLDER/bstrap.py
-  curl -fsSL -o "$script" "https://raw.githubusercontent.com/codrsquad/pickley/master/$bstrap"
+  curl -fsSL -o "$script" "https://raw.githubusercontent.com/codrsquad/pickley/main/$bstrap"
 fi
 
 $python "$script" "$@"

--- a/src/pickley/delivery.py
+++ b/src/pickley/delivery.py
@@ -45,7 +45,7 @@ else
     echo "{source} is not available anymore"
     echo ""
     echo "Please reinstall with:"
-    echo '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/master/get-pickley)"'
+    echo '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/codrsquad/pickley/main/get-pickley)"'
     exit 1
 fi
 """ % WRAPPER_MARK

--- a/tests/samples/bogus-config/custom.json
+++ b/tests/samples/bogus-config/custom.json
@@ -3,7 +3,6 @@
     "foo": "bar",
     "include": ["bogus.json", "/dev/null/non-existent-config-file.json"],
     "install_timeout": 250,
-    "pyenv": "/dev/null",
     "python": "/dev/null, /dev/null/foo",
     "version_check_delay": 15
 }

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -59,14 +59,14 @@ def test_bootstrap(cli, monkeypatch):
             assert "Make sure ~/.local/bin is writeable and in your PATH variable." in cli.logged
 
             # Simulate seeding
+            sample_config = '"python-installations": "~/.pyenv/version/**"'
             monkeypatch.setenv("PATH", ".local/bin:%s" % os.environ["PATH"])
-            cli.run("0.1", "-b", "~/.local/bin", "-m", "my-mirror", "-c", '{"pyenv":"~/.pyenv"}', main=bstrap.main)
-            assert cli.succeeded
-            assert f"Seeding .local/bin/{DOT_META}/config.json with {{'pyenv': '~/.pyenv'}}" in cli.logged
+            cli.run("0.1", "-b", "~/.local/bin", "-m", "my-mirror", "-c", f"{{{sample_config}}}", main=bstrap.main)
+            assert f"Seeding .local/bin/{DOT_META}/config.json with " in cli.logged
             assert "Seeding .config/pip/pip.conf with my-mirror" in cli.logged
             assert "pickley version 0.1 is already installed" in cli.logged
             assert list(runez.readlines(".config/pip/pip.conf")) == ["[global]", "index-url = my-mirror"]
-            assert list(runez.readlines(f".local/bin/{DOT_META}/config.json")) == ["{", '  "pyenv": "~/.pyenv"', "}"]
+            assert list(runez.readlines(f".local/bin/{DOT_META}/config.json")) == ["{", f"  {sample_config}", "}"]
 
             monkeypatch.setenv("PATH", "foo/bar:%s" % os.environ["PATH"])
             runez.ensure_folder("foo/bar", logger=None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,6 @@ cli:  # empty
    - bogus.json
    - /dev/null/non-existent-config-file.json
   install_timeout: 250
-  pyenv: /dev/null
   python: /dev/null, /dev/null/foo
   version_check_delay: 15
 
@@ -62,7 +61,6 @@ def grab_sample(name):
 
 def test_bogus_config(temp_folder, logged):
     cfg = grab_sample("bogus-config")
-    assert cfg.pyenv() == "/dev/null"  # from custom.json
     assert cfg.resolved_bundle("") == []
     assert cfg.resolved_bundle("foo") == ["foo"]
     assert cfg.resolved_bundle("bundle:dev") == ["tox", "mgit"]


### PR DESCRIPTION
Where to look for python installations configured optionally via `python-installations` (instead of `pyenv`)

This is a feature that would only impact automated/managed installs of `pickley`, default should continue to work great for most users.