### PR TITLE
Use uv by default

### DIFF
--- a/src/pickley/__init__.py
+++ b/src/pickley/__init__.py
@@ -489,7 +489,7 @@ class PickleyConfig:
 
         self._add_config_file(self.config_path)
         self._add_config_file(self.meta.full_path("config.json"))
-        package_manager = os.getenv("PICKLEY_PACKAGE_MANAGER") or "pip"
+        package_manager = os.getenv("PICKLEY_PACKAGE_MANAGER") or "uv"
         defaults = {"delivery": "wrap", "install_timeout": 1800, "version_check_delay": 300, "package_manager": package_manager}
         self.configs.append(RawConfig(self, "defaults", defaults))
 

--- a/src/pickley/__init__.py
+++ b/src/pickley/__init__.py
@@ -13,6 +13,7 @@ from pickley.bstrap import DOT_META, http_get, PICKLEY
 
 __version__ = "4.2.2"
 LOG = logging.getLogger(__name__)
+DEFAULT_PACKAGE_MANAGER = "uv" if sys.version_info[:2] >= (3, 8) else "pip"
 K_CLI = {"delivery", "index", "python"}
 K_DIRECTIVES = {"include"}
 K_GROUPS = {"bundle", "pinned"}
@@ -489,7 +490,7 @@ class PickleyConfig:
 
         self._add_config_file(self.config_path)
         self._add_config_file(self.meta.full_path("config.json"))
-        package_manager = os.getenv("PICKLEY_PACKAGE_MANAGER") or "uv"
+        package_manager = os.getenv("PICKLEY_PACKAGE_MANAGER") or DEFAULT_PACKAGE_MANAGER
         defaults = {"delivery": "wrap", "install_timeout": 1800, "version_check_delay": 300, "package_manager": package_manager}
         self.configs.append(RawConfig(self, "defaults", defaults))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import runez
 
@@ -53,6 +55,7 @@ def grab_sample(name):
     return cfg
 
 
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 7), reason="Default is uv only on py3.8+")
 def test_bogus_config(temp_cfg, logged):
     cfg = grab_sample("bogus-config")
     assert cfg.resolved_bundle("") == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,7 +38,7 @@ cli:  # empty
 defaults:
   delivery: wrap
   install_timeout: 1800
-  package_manager: pip
+  package_manager: uv
   version_check_delay: 300
 """
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -334,6 +334,7 @@ def check_install_from_pypi(cli, delivery, package, version=None, simulate_versi
         cli.expect_success("check", f"{installed_version} (currently {simulate_version} unhealthy)")
 
 
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 6), reason="uv does not recognize py3.6")
 def test_install_pypi(cli):
     check_install_from_pypi(cli, "symlink", "uv")
 
@@ -381,6 +382,7 @@ def test_install_pypi(cli):
     assert "Auto-healed 1 / 2 packages" in cli.logged
 
 
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 6), reason="uv does not recognize py3.6")
 def test_invalid(cli):
     cli.run("--color install six")
     assert cli.failed


### PR DESCRIPTION
Version 4.3 will use `uv` by default