### PR TITLE
Honor /etc/pip.conf if possible

### DIFF
--- a/src/pickley/bstrap.py
+++ b/src/pickley/bstrap.py
@@ -18,6 +18,7 @@ DOT_META = ".pk"
 DRYRUN = False
 HOME = os.path.expanduser("~")
 PICKLEY = "pickley"
+DEFAULT_MIRROR = "https://pypi.org/simple"
 
 
 def abort(message):
@@ -159,26 +160,23 @@ def find_base(base):
     abort(f"Make sure '{candidates[0]}' is writeable.")
 
 
-def globally_configured_pypi_mirror():  # pragma: no-cover, best-effort honoring of /etc/pip.conf
+def globally_configured_pypi_mirror(pip_conf_path="/etc/pip.conf"):
     """
     Honor the pypi mirror as configured in `/etc/pip.conf`.
     We can't rely on bringing in a library to help parse the config, as this script needs to be able to run ad-hoc.
     Best-effort parsing, any complex `pip.conf` will be ignored.
     """
     try:
-        import re
+        import configparser
 
-        regex = re.compile(r"^index-url\s*=\s*['\"]?(http[^'\"\s]+)['\"]?")
-        with open("/etc/pip.conf") as fh:
-            for line in fh:
-                m = regex.match(line)
-                if m:
-                    return m.group(1)
+        config = configparser.ConfigParser()
+        config.read(pip_conf_path)
+        return config["global"]["index-url"]
 
     except Exception:
         pass
 
-    return "https://pypi.org/simple"
+    return DEFAULT_MIRROR
 
 
 def get_latest_pickley_version(mirror):

--- a/src/pickley/bstrap.py
+++ b/src/pickley/bstrap.py
@@ -162,9 +162,7 @@ def find_base(base):
 
 def globally_configured_pypi_mirror(pip_conf_path="/etc/pip.conf"):
     """
-    Honor the pypi mirror as configured in `/etc/pip.conf`.
-    We can't rely on bringing in a library to help parse the config, as this script needs to be able to run ad-hoc.
-    Best-effort parsing, any complex `pip.conf` will be ignored.
+    Best-effort parsing of /etc/pip.conf to honor globally configured mirror.
     """
     try:
         import configparser
@@ -173,10 +171,13 @@ def globally_configured_pypi_mirror(pip_conf_path="/etc/pip.conf"):
         config.read(pip_conf_path)
         return config["global"]["index-url"]
 
-    except Exception:
-        pass
+    except (KeyError, OSError):
+        return DEFAULT_MIRROR
 
-    return DEFAULT_MIRROR
+    except Exception as e:
+        # Ignore any issue reading pip.conf, not necessary for bootstrap
+        print(f"Could not read {pip_conf_path}: {e}")
+        return DEFAULT_MIRROR
 
 
 def get_latest_pickley_version(mirror):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -216,9 +216,14 @@ def test_pip_conf(logged):
         runez.write("pip.conf", f"[global]\nindex-url = {mirror}", logger=None)
         assert bstrap.globally_configured_pypi_mirror("pip.conf") == mirror
 
-        # Invalid file gets ignored (no crash, no complaints)
+        # Mirror not configured
         runez.write("pip.conf", "[foo]\nbar = baz", logger=None)
         assert bstrap.globally_configured_pypi_mirror("pip.conf") == bstrap.DEFAULT_MIRROR
 
-    # Check that no chatter occurred (no stack trace etc)
-    assert not logged
+        # Check that no chatter occurred so far (no stack trace etc.)
+        assert not logged
+
+        # Invalid file gets ignored (we do report error)
+        runez.write("pip.conf", "this is not an ini file", logger=None)
+        assert bstrap.globally_configured_pypi_mirror("pip.conf") == bstrap.DEFAULT_MIRROR
+        assert "Could not read pip.conf: "


### PR DESCRIPTION
This should avoid the edge case where attempts to bootstrap pickley temporarily fail due to internal mirrors not having ingested the upstream pypi.org publication yet.