### PR TITLE
Corrected --symlink in package command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ __pycache__/
 .venv*/
 build/
 dist/
-root/
 venv*/

--- a/src/pickley/cli.py
+++ b/src/pickley/cli.py
@@ -844,8 +844,7 @@ class Symlinker:
         if not self.base or not self.target:
             abort(f"Invalid symlink specification '{spec}'")
 
-        self.base = runez.resolved_path(self.base)
-        self.target = runez.resolved_path(self.target)
+        self.target = runez.resolved_path(self.target, base=CFG.base.path)
 
     def apply(self, exe):
         dest = os.path.join(self.target, os.path.basename(exe))

--- a/src/pickley/cli.py
+++ b/src/pickley/cli.py
@@ -761,7 +761,7 @@ class PackageFinalizer:
         self.cfg = cfg
         self.folder = runez.resolved_path(project)
         self.dist = dist
-        self.symlink = Symlinker(symlink) if symlink else None
+        self.symlink = Symlinker(symlink, cfg.base.path) if symlink else None
         self.sanity_check = None
         self.compile = True
         self.border = "reddit"
@@ -839,12 +839,12 @@ def does_not_implement_cli_flag(*messages):
 
 
 class Symlinker:
-    def __init__(self, spec):
+    def __init__(self, spec, base):
         self.base, _, self.target = spec.partition(":")
         if not self.base or not self.target:
             abort(f"Invalid symlink specification '{spec}'")
 
-        self.target = runez.resolved_path(self.target, base=CFG.base.path)
+        self.target = runez.resolved_path(self.target, base=base)
 
     def apply(self, exe):
         dest = os.path.join(self.target, os.path.basename(exe))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -427,24 +427,16 @@ def test_package_venv(cli):
     # TODO: retire the `package` command, not worth the effort to support it
     # Verify that "debian mode" works as expected, with -droot/tmp <-> /tmp
     runez.delete("/tmp/pickley")
-    cli.run("package", cli.project_folder, "-droot/tmp", "--no-compile", "--sanity-check=--version", "-sroot:root/usr/local/bin")
-    assert cli.succeeded
-    assert "--version" in cli.logged
-    assert runez.is_executable("/tmp/pickley/bin/pip3")
-    assert runez.is_executable("/tmp/pickley/bin/pickley")
-    r = runez.run("/tmp/pickley/bin/pickley", "--version")
-    assert r.succeeded
-    runez.delete("/tmp/pickley")
-
-
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 12), reason="setuptools is not available in py3.12")
-def test_package_venv_with_additional_packages(cli):
-    # TODO: retire the `package` command, not worth the effort to support it
-    runez.delete("/tmp/pickley")
-    cli.run("package", "-droot/tmp", "-sroot:root/usr/local/bin", cli.project_folder)
+    cli.run("package", cli.project_folder, "-droot/tmp", "--no-compile", "--sanity-check=--version", "-sroot:root/usr/local/bin", "runez")
     assert cli.succeeded
     assert "pip install -r requirements.txt" in cli.logged
-    assert runez.is_executable("/tmp/pickley/bin/pip3")
+    assert "pip install runez" in cli.logged
+    assert "pickley --version" in cli.logged
+    assert "Symlinked root/usr/local/bin/pickley -> /tmp/pickley/bin/pickley" in cli.logged
+    assert os.path.islink("build/root/usr/local/bin/pickley")
+    rp = os.path.realpath("build/root/usr/local/bin/pickley")
+    assert os.path.exists(rp)
+    assert runez.is_executable("/tmp/pickley/bin/python")
     assert runez.is_executable("/tmp/pickley/bin/pickley")
     r = runez.run("/tmp/pickley/bin/pickley", "--version")
     assert r.succeeded


### PR DESCRIPTION
Use full path when honoring the --symlink flag of `package` command